### PR TITLE
Configure GitHub Pages for custom domain

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_react_typescript",
-  "homepage": "http://santiagosalazarpavajeau.github.io/",
+  "homepage": "https://santiagosalazarpavajeau.live",
   "version": "0.1.0",
   "private": true,
   "dependencies": {

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+santiagosalazarpavajeau.live

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders portfolio header', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const headingElement = screen.getByText(/Santiago Salazar Pavajeau/i);
+  expect(headingElement).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- set site homepage to custom domain
- add `CNAME` file for GitHub Pages
- update unit test to match portfolio content

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b20960a5cc8325be54f7352f44ecc6