### PR TITLE
Add CNAME and deployment instructions for custom domain

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+santiagosalazarpavajeau.live

--- a/README.md
+++ b/README.md
@@ -44,3 +44,21 @@ You don’t have to ever use `eject`. The curated feature set is suitable for sm
 You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
 
 To learn React, check out the [React documentation](https://reactjs.org/).
+
+## Deployment
+
+This project is configured to deploy to a custom domain using GitHub Pages.
+
+1. Ensure this repository has a remote pointing at your GitHub Pages repo:
+   ```bash
+   git remote add origin git@github.com:SantiagoSalazarPavajeau/santiagosalazarpavajeau.github.io.git
+   ```
+2. Commit any changes and run the deployment script:
+   ```bash
+   npm run deploy
+   ```
+   This builds the project and publishes the contents of the `build` folder to the `gh-pages` branch.
+
+3. Verify that the `CNAME` file contains `santiagosalazarpavajeau.live` so GitHub Pages serves the site at the custom domain.
+
+After DNS records propagate, the portfolio will be available at [https://santiagosalazarpavajeau.live](https://santiagosalazarpavajeau.live).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_react_typescript",
-  "homepage": "http://santiagosalazarpavajeau.github.io/",
+  "homepage": "https://santiagosalazarpavajeau.live",
   "version": "0.1.0",
   "private": true,
   "dependencies": {

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+santiagosalazarpavajeau.live

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders portfolio header', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const headingElement = screen.getByText(/Santiago Salazar Pavajeau/i);
+  expect(headingElement).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- add root-level CNAME for `santiagosalazarpavajeau.live`
- document how to deploy to GitHub Pages custom domain

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b20960a5cc8325be54f7352f44ecc6